### PR TITLE
Unescape quotes in extracted strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,9 @@ function trim(str) {
 function trimQuotes(str) {
   return str.replace(/^['"`]|['"`]$/g, '');
 }
+function unescapeQuotes(str) {
+  return str.replace(/\\(['"])/g, '$1');
+}
 
 /**
  * Constructor
@@ -98,7 +101,7 @@ Parser.prototype.parse = function parse(template) {
   // eslint-disable-next-line no-cond-assign
   while ((match = this.expressionPattern.exec(template)) !== null) {
     const keyword = match[1];
-    const params = match[2].match(this.stringPattern).map(trim).map(trimQuotes);
+    const params = match[2].match(this.stringPattern).map(trim).map(trimQuotes).map(unescapeQuotes);
 
     const spec = this.keywordSpec[keyword];
     const msgidIndex = spec.msgid;

--- a/package.json
+++ b/package.json
@@ -3,8 +3,12 @@
   "version": "0.3.0",
   "description": "Extract translatable strings from Vue files",
   "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
   "scripts": {
-    "lint": "eslint index.js"
+    "pretest": "eslint index.js",
+    "test": "ava ./test/test.js"
   },
   "repository": "https://github.com/GUI/gettext-vue.git",
   "keywords": [
@@ -21,6 +25,7 @@
   },
   "homepage": "https://github.com/GUI/gettext-vue",
   "devDependencies": {
+    "ava": "^0.24.0",
     "eslint": "^4.14.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.8.0"

--- a/test/fixtures/singular.vue
+++ b/test/fixtures/singular.vue
@@ -1,0 +1,22 @@
+<template>
+    <div>
+        <h1 :title="$t('Description')">{{ $t("This is a title") }}</h1>
+        <p :title="$t('Description')">{{ $t('This is wrapped in single quotes') }}</p>
+        <p>{{ $t('\'single escape\'') }}</p>
+        <p>{{ $t("\"double escape\"") }}</p>
+        <p>{{ $t("word \"escaped, word\", with comma") }}</p>
+        <p>{{ $t("ending with an escaped quote\"") }}</p>
+    </div>
+</template>
+
+<script>
+    export default {
+        data: function () {
+            return {
+                t1: this.$t('data \'single escape\''),
+                t2: this.$t("data \"double escape\""),
+                t3: this.$t("Description")
+            };
+        }
+    }
+</script>

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,28 @@
+import Parser from '..';
+import fs from 'fs';
+import test from 'ava';
+
+test('default', t => {
+    t.deepEqual((new Parser()).keywordSpec.$t, { msgid : 0 },
+        'should have default keyword spec when none is passed');
+});
+
+test.cb('singular', t => {
+    fs.readFile(__dirname + '/fixtures/singular.vue', {encoding: 'utf8'}, (err, data) => {
+        if (err) throw err;
+
+        const result = (new Parser()).parse(data);
+        t.is(typeof result, 'object');
+        t.true('This is a title' in result);
+        t.true('This is wrapped in single quotes' in result);
+        t.true('\'single escape\'' in result);
+        t.true('"double escape"' in result);
+        t.true('word "escaped, word", with comma' in result);
+        t.true('ending with an escaped quote"' in result);
+        t.true('data \'single escape\'' in result);
+        t.true('data "double escape"' in result);
+        t.true('Description' in result);
+        t.is(result['Description'].line.length, 3);
+        t.end();
+    });
+});


### PR DESCRIPTION
Avoid escaped single quotes and double-escaped double quotes on msgid/msgstr in PO files

Add some tests to ensure that extracted strings do not contain escaped quotes (based on test found on gettext-ejs project)